### PR TITLE
docs: center Hermes Chat diagram shape

### DIFF
--- a/assets/diagrams/home-hermes-setup.svg
+++ b/assets/diagrams/home-hermes-setup.svg
@@ -46,29 +46,29 @@
 <text x="526" y="622" class="category">MEMORY + CONTEXT</text>
 
 <!-- Connections behind cards -->
-<path d="M385,285 C435,285 475,300 545,300" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
-<path d="M385,425 C455,425 485,302 545,302" fill="none" stroke="#16a34a" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<path d="M385,425 C435,425 475,300 545,300" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
+<path d="M385,295 C455,295 485,302 545,302" fill="none" stroke="#16a34a" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-green)"/>
 <path d="M645,340 C675,372 708,395 745,420" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
 <path d="M920,340 C895,360 862,385 825,405" fill="none" stroke="#0f766e" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
 <path d="M745,530 C720,558 700,588 680,615" fill="none" stroke="#7c3aed" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
 <path d="M825,530 C855,562 902,592 940,615" fill="none" stroke="#ea580c" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-orange)"/>
 <path d="M935,452 C1025,360 1090,278 1190,278" fill="none" stroke="#dc2626" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-red)"/>
 <path d="M935,475 C1045,445 1085,397 1190,397" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
-<path d="M935,500 C1045,515 1085,548 1190,548" fill="none" stroke="#9333ea" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
+<path d="M935,500 C1045,565 1085,674 1190,674" fill="none" stroke="#9333ea" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
 
 <!-- Access cards -->
-<g id="mac" filter="url(#shadow)">
-  <rect x="115" y="243" width="270" height="84" rx="18" fill="#ffffff"/>
-  <rect x="115" y="243" width="270" height="84" rx="18" fill="#dbeafe" stroke="#2563eb" stroke-width="2.5"/>
-  <text x="137" y="275" class="card-title">MacBook</text>
-  <text x="137" y="303" class="card-body">RDP / SSH / browser</text>
-</g>
 <g id="phone" filter="url(#shadow)">
-  <rect x="115" y="373" width="270" height="104" rx="18" fill="#ffffff"/>
-  <rect x="115" y="373" width="270" height="104" rx="18" fill="#dcfce7" stroke="#16a34a" stroke-width="2.5"/>
-  <text x="137" y="405" class="card-title">Phone</text>
-  <text x="137" y="433" class="card-body">WhatsApp / voice notes</text>
-  <text x="137" y="455" class="card-body-strong">enters through Gateway</text>
+  <rect x="115" y="243" width="270" height="104" rx="18" fill="#ffffff"/>
+  <rect x="115" y="243" width="270" height="104" rx="18" fill="#dcfce7" stroke="#16a34a" stroke-width="2.5"/>
+  <text x="137" y="275" class="card-title">Phone</text>
+  <text x="137" y="303" class="card-body">WhatsApp / voice notes</text>
+  <text x="137" y="325" class="card-body-strong">enters through Gateway</text>
+</g>
+<g id="mac" filter="url(#shadow)">
+  <rect x="115" y="383" width="270" height="84" rx="18" fill="#ffffff"/>
+  <rect x="115" y="383" width="270" height="84" rx="18" fill="#dbeafe" stroke="#2563eb" stroke-width="2.5"/>
+  <text x="137" y="415" class="card-title">MacBook</text>
+  <text x="137" y="443" class="card-body">RDP / SSH / browser</text>
 </g>
 <g id="operator" filter="url(#shadow)">
   <rect x="115" y="540" width="270" height="104" rx="18" fill="#ffffff"/>
@@ -102,7 +102,8 @@
   <rect x="535" y="635" width="285" height="86" rx="18" fill="#ffffff"/>
   <rect x="535" y="635" width="285" height="86" rx="18" fill="#ede9fe" stroke="#7c3aed" stroke-width="2.5"/>
   <text x="557" y="667" class="card-title">Honcho</text>
-  <text x="557" y="695" class="card-body-strong">agent memory + recall</text>
+  <text x="557" y="690" class="card-body-strong">session-persistent agent memory</text>
+  <text x="557" y="712" class="card-body">recall + user modeling</text>
 </g>
 <g id="obsidian" filter="url(#shadow)">
   <rect x="850" y="635" width="220" height="86" rx="18" fill="#ffffff"/>
@@ -132,39 +133,38 @@
   <text x="1212" y="437" class="card-title">Cursor Agent CLI + Codex CLI</text>
   <text x="1212" y="465" class="card-body">implementation delegates</text>
 </g>
-<text x="1190" y="530" class="category">WEB APPS</text>
-<g id="webapps" filter="url(#shadow)">
-  <rect x="1190" y="548" width="405" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1190" y="548" width="405" height="84" rx="18" fill="#f3e8ff" stroke="#9333ea" stroke-width="2.5"/>
-  <text x="1212" y="580" class="card-title">Web apps</text>
-  <text x="1212" y="608" class="card-body">public product surfaces</text>
-</g>
+<text x="1190" y="520" class="category">SHIPPING STACK</text>
 <g id="shipping-stack-box">
-  <rect x="1165" y="650" width="445" height="104" rx="20" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="8 7"/>
-  <text x="1187" y="678" class="category">SHIPPING STACK</text>
+  <rect x="1165" y="538" width="445" height="98" rx="20" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="8 7"/>
 </g>
-<path d="M1392,650 L1392,632" fill="none" stroke="#64748b" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
 <g id="github" filter="url(#shadow)">
-  <rect x="1185" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
-  <rect x="1185" y="692" width="122" height="46" rx="14" fill="#e2e8f0" stroke="#64748b" stroke-width="2"/>
-  <text x="1206" y="722" class="small">GitHub</text>
+  <rect x="1185" y="578" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1185" y="578" width="122" height="46" rx="14" fill="#e2e8f0" stroke="#64748b" stroke-width="2"/>
+  <text x="1206" y="608" class="small">GitHub</text>
 </g>
 <g id="vercel" filter="url(#shadow)">
-  <rect x="1328" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
-  <rect x="1328" y="692" width="122" height="46" rx="14" fill="#e0f2fe" stroke="#0284c7" stroke-width="2"/>
-  <text x="1351" y="722" class="small">Vercel</text>
+  <rect x="1328" y="578" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1328" y="578" width="122" height="46" rx="14" fill="#e0f2fe" stroke="#0284c7" stroke-width="2"/>
+  <text x="1351" y="608" class="small">Vercel</text>
 </g>
 <g id="supabase" filter="url(#shadow)">
-  <rect x="1470" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
-  <rect x="1470" y="692" width="122" height="46" rx="14" fill="#dcfce7" stroke="#16a34a" stroke-width="2"/>
-  <text x="1491" y="722" class="small">Supabase</text>
+  <rect x="1470" y="578" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1470" y="578" width="122" height="46" rx="14" fill="#dcfce7" stroke="#16a34a" stroke-width="2"/>
+  <text x="1491" y="608" class="small">Supabase</text>
+</g>
+<path d="M1392,636 L1392,674" fill="none" stroke="#64748b" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
+<g id="webapps" filter="url(#shadow)">
+  <rect x="1190" y="674" width="405" height="84" rx="18" fill="#ffffff"/>
+  <rect x="1190" y="674" width="405" height="84" rx="18" fill="#f3e8ff" stroke="#9333ea" stroke-width="2.5"/>
+  <text x="1212" y="706" class="card-title">Web apps</text>
+  <text x="1212" y="734" class="card-body">public product surfaces</text>
 </g>
 
 <!-- Compact flow labels -->
-<rect x="430" y="255" width="128" height="24" rx="8" fill="#fbfdff" stroke="#2563eb" stroke-width="1" opacity="0.96"/>
-<text x="438" y="272" class="small" fill="#2563eb">remote control</text>
-<rect x="416" y="350" width="146" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
-<text x="424" y="367" class="small" fill="#16a34a">phone → gateway</text>
+<rect x="430" y="398" width="128" height="24" rx="8" fill="#fbfdff" stroke="#2563eb" stroke-width="1" opacity="0.96"/>
+<text x="438" y="415" class="small" fill="#2563eb">remote control</text>
+<rect x="416" y="255" width="146" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
+<text x="424" y="272" class="small" fill="#16a34a">phone → gateway</text>
 <rect x="640" y="374" width="118" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
 <text x="648" y="391" class="small" fill="#16a34a">chat ingress</text>
 <rect x="840" y="374" width="92" height="24" rx="8" fill="#fbfdff" stroke="#0f766e" stroke-width="1" opacity="0.96"/>
@@ -177,8 +177,8 @@
 <text x="1046" y="341" class="small" fill="#dc2626">LLMs</text>
 <rect x="1038" y="500" width="130" height="24" rx="8" fill="#fbfdff" stroke="#9333ea" stroke-width="1" opacity="0.96"/>
 <text x="1046" y="517" class="small" fill="#9333ea">web work</text>
-<rect x="1328" y="632" width="130" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
-<text x="1336" y="649" class="small" fill="#64748b">ships web apps</text>
+<rect x="1328" y="638" width="130" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
+<text x="1336" y="655" class="small" fill="#64748b">ships web apps</text>
 
 <!-- Legend and operating notes -->
 <g transform="translate(90,830)">
@@ -202,6 +202,6 @@
   <text x="600" y="950" class="subtitle">Around it by category: Gateway and Agent above, memory/context below, external services to the right.</text>
   <text x="600" y="982" class="subtitle">Hermes Gateway is not memory; it is messaging ingress. Phone/WhatsApp reaches Gateway first, then Chat.</text>
   <text x="600" y="1014" class="subtitle">Honcho is agent memory for recall and profile context. Obsidian is external memory as human notes.</text>
-  <text x="600" y="1046" class="subtitle">GitHub, Vercel, and Supabase are grouped as the shipping stack that feeds the generic Web apps surface.</text>
+  <text x="600" y="1046" class="subtitle">GitHub, Vercel, and Supabase sit above Web apps as the shipping stack that feeds the generic surface.</text>
 </g>
 </svg>

--- a/assets/diagrams/home-hermes-setup.svg
+++ b/assets/diagrams/home-hermes-setup.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1700" height="1180" viewBox="0 0 1700 1180" role="img" aria-labelledby="title desc">
 <title id="title">Home AI Operating Layer — Hermes Chat as the Strategic Center</title>
-<desc id="desc">Architecture diagram of Alfons' home Hermes setup. Hermes Chat is physically centered inside the Fedora mini PC column, with categories arranged around it: access surfaces on the left, gateway ingress and execution tools above, memory below, and external systems plus web apps on the right.</desc>
+<desc id="desc">Architecture diagram of Alfons' home Hermes setup. Hermes Chat is physically centered inside the Fedora mini PC column, with categories arranged around it: access surfaces on the left, gateway ingress and execution tools above, memory below, and external systems and a generic web apps surface on the right.</desc>
 <defs>
   <marker id="arrow-blue" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#2563eb"/></marker>
   <marker id="arrow-green" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#16a34a"/></marker>
@@ -55,11 +55,6 @@
 <path d="M935,452 C1025,360 1090,278 1190,278" fill="none" stroke="#dc2626" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-red)"/>
 <path d="M935,475 C1045,445 1085,397 1190,397" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
 <path d="M935,500 C1045,515 1085,548 1190,548" fill="none" stroke="#9333ea" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
-<path d="M1392,590 L1392,642" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
-<path d="M1320,590 C1280,620 1248,636 1215,650" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
-<path d="M1428,590 C1490,620 1535,640 1568,650" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
-<path d="M1320,692 L1348,692" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
-<path d="M1508,692 L1530,692" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
 
 <!-- Access cards -->
 <g id="mac" filter="url(#shadow)">
@@ -137,30 +132,32 @@
   <text x="1212" y="437" class="card-title">Cursor Agent CLI + Codex CLI</text>
   <text x="1212" y="465" class="card-body">implementation delegates</text>
 </g>
-<text x="1190" y="530" class="category">WEB APPS + SHIPPING</text>
+<text x="1190" y="530" class="category">WEB APPS</text>
 <g id="webapps" filter="url(#shadow)">
   <rect x="1190" y="548" width="405" height="84" rx="18" fill="#ffffff"/>
   <rect x="1190" y="548" width="405" height="84" rx="18" fill="#f3e8ff" stroke="#9333ea" stroke-width="2.5"/>
   <text x="1212" y="580" class="card-title">Web apps</text>
-  <text x="1212" y="608" class="card-body">SavedTube + dashboards + product UI</text>
+  <text x="1212" y="608" class="card-body">public product surfaces</text>
 </g>
+<g id="shipping-stack-box">
+  <rect x="1165" y="650" width="445" height="104" rx="20" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="8 7"/>
+  <text x="1187" y="678" class="category">SHIPPING STACK</text>
+</g>
+<path d="M1392,650 L1392,632" fill="none" stroke="#64748b" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
 <g id="github" filter="url(#shadow)">
-  <rect x="1165" y="650" width="160" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1165" y="650" width="160" height="84" rx="18" fill="#e2e8f0" stroke="#64748b" stroke-width="2.5"/>
-  <text x="1187" y="682" class="card-title">GitHub</text>
-  <text x="1187" y="710" class="card-body">source + PRs</text>
+  <rect x="1185" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1185" y="692" width="122" height="46" rx="14" fill="#e2e8f0" stroke="#64748b" stroke-width="2"/>
+  <text x="1206" y="722" class="small">GitHub</text>
 </g>
 <g id="vercel" filter="url(#shadow)">
-  <rect x="1348" y="650" width="160" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1348" y="650" width="160" height="84" rx="18" fill="#e0f2fe" stroke="#0284c7" stroke-width="2.5"/>
-  <text x="1370" y="682" class="card-title">Vercel</text>
-  <text x="1370" y="710" class="card-body">deploys</text>
+  <rect x="1328" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1328" y="692" width="122" height="46" rx="14" fill="#e0f2fe" stroke="#0284c7" stroke-width="2"/>
+  <text x="1351" y="722" class="small">Vercel</text>
 </g>
 <g id="supabase" filter="url(#shadow)">
-  <rect x="1530" y="650" width="80" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1530" y="650" width="80" height="84" rx="18" fill="#dcfce7" stroke="#16a34a" stroke-width="2.5"/>
-  <text x="1544" y="682" class="card-title">DB</text>
-  <text x="1543" y="710" class="tiny">Supabase</text>
+  <rect x="1470" y="692" width="122" height="46" rx="14" fill="#ffffff"/>
+  <rect x="1470" y="692" width="122" height="46" rx="14" fill="#dcfce7" stroke="#16a34a" stroke-width="2"/>
+  <text x="1491" y="722" class="small">Supabase</text>
 </g>
 
 <!-- Compact flow labels -->
@@ -179,9 +176,9 @@
 <rect x="1038" y="324" width="82" height="24" rx="8" fill="#fbfdff" stroke="#dc2626" stroke-width="1" opacity="0.96"/>
 <text x="1046" y="341" class="small" fill="#dc2626">LLMs</text>
 <rect x="1038" y="500" width="130" height="24" rx="8" fill="#fbfdff" stroke="#9333ea" stroke-width="1" opacity="0.96"/>
-<text x="1046" y="517" class="small" fill="#9333ea">product work</text>
-<rect x="1334" y="626" width="118" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
-<text x="1342" y="643" class="small" fill="#64748b">ship path</text>
+<text x="1046" y="517" class="small" fill="#9333ea">web work</text>
+<rect x="1328" y="632" width="130" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
+<text x="1336" y="649" class="small" fill="#64748b">ships web apps</text>
 
 <!-- Legend and operating notes -->
 <g transform="translate(90,830)">
@@ -205,6 +202,6 @@
   <text x="600" y="950" class="subtitle">Around it by category: Gateway and Agent above, memory/context below, external services to the right.</text>
   <text x="600" y="982" class="subtitle">Hermes Gateway is not memory; it is messaging ingress. Phone/WhatsApp reaches Gateway first, then Chat.</text>
   <text x="600" y="1014" class="subtitle">Honcho is agent memory for recall and profile context. Obsidian is external memory as human notes.</text>
-  <text x="600" y="1046" class="subtitle">Web apps sit outside the machine with GitHub source/PRs, Vercel deploys, and Supabase data.</text>
+  <text x="600" y="1046" class="subtitle">GitHub, Vercel, and Supabase are grouped as the shipping stack that feeds the generic Web apps surface.</text>
 </g>
 </svg>

--- a/assets/diagrams/home-hermes-setup.svg
+++ b/assets/diagrams/home-hermes-setup.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1700" height="1180" viewBox="0 0 1700 1180" role="img" aria-labelledby="title desc">
 <title id="title">Home AI Operating Layer — Hermes Chat as the Strategic Center</title>
-<desc id="desc">Architecture diagram of Alfons' home Hermes setup. Hermes Chat sits at the center of the Fedora mini PC strategy, reached through Hermes Gateway from phone and messaging channels, connected to Honcho and Obsidian as memory, and to web apps through GitHub, Vercel, and Supabase.</desc>
+<desc id="desc">Architecture diagram of Alfons' home Hermes setup. Hermes Chat is physically centered inside the Fedora mini PC column, with categories arranged around it: access surfaces on the left, gateway ingress and execution tools above, memory below, and external systems plus web apps on the right.</desc>
 <defs>
   <marker id="arrow-blue" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#2563eb"/></marker>
   <marker id="arrow-green" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#16a34a"/></marker>
@@ -8,15 +8,17 @@
   <marker id="arrow-orange" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#ea580c"/></marker>
   <marker id="arrow-gray" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#64748b"/></marker>
   <marker id="arrow-red" markerWidth="12" markerHeight="9" refX="10" refY="4.5" orient="auto"><path d="M0,0 L12,4.5 L0,9 Z" fill="#dc2626"/></marker>
-  <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="4" stdDeviation="9" flood-color="#0f172a" flood-opacity="0.14"/></filter>
+  <filter id="shadow" x="-12%" y="-12%" width="124%" height="124%"><feDropShadow dx="0" dy="4" stdDeviation="9" flood-color="#0f172a" flood-opacity="0.14"/></filter>
   <style>
     .title { font: 800 36px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #111827; }
     .subtitle { font: 400 17px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #4b5563; }
     .machine { font: 600 15px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #475569; }
     .section { font: 800 21px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #111827; }
+    .category { font: 800 14px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #475569; letter-spacing: .04em; }
     .card-title { font: 800 18px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #111827; }
+    .center-title { font: 900 24px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #0f172a; }
     .card-body { font: 400 15px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #374151; }
-    .card-body-strong { font: 700 15px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #1f2937; }
+    .card-body-strong { font: 800 15px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #1f2937; }
     .small { font: 700 13px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #334155; }
     .caption { font: 500 14px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #475569; }
     .tiny { font: 600 12px Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; fill: #64748b; }
@@ -27,27 +29,37 @@
 <text x="80" y="98" class="subtitle">Hermes Chat is the center of the strategy: the conversation surface that coordinates memory, tools, agents, and shipping.</text>
 <text x="80" y="126" class="machine">Machine: fedora.home · Fedora Linux 44 · AMD Ryzen 3 3300U · 13Gi RAM · 475G disk · kernel 6.19.10-300.fc44.x86_64</text>
 
-<!-- Columns -->
+<!-- Main columns -->
 <rect x="70" y="165" width="360" height="610" rx="24" fill="#f8fafc" stroke="#94a3b8" stroke-width="2" stroke-dasharray="10 9"/>
-<text x="98" y="207" class="section" fill="#94a3b8">Access surfaces</text>
+<text x="98" y="207" class="section">Access surfaces</text>
 <rect x="475" y="165" width="620" height="610" rx="24" fill="#eff6ff" stroke="#60a5fa" stroke-width="2" stroke-dasharray="10 9"/>
-<text x="503" y="207" class="section" fill="#60a5fa">Home Fedora mini PC</text>
+<text x="503" y="207" class="section">Home Fedora mini PC</text>
 <rect x="1140" y="165" width="485" height="610" rx="24" fill="#fffbeb" stroke="#f59e0b" stroke-width="2" stroke-dasharray="10 9"/>
-<text x="1168" y="207" class="section" fill="#f59e0b">External systems + web apps</text>
+<text x="1168" y="207" class="section">External systems + web apps</text>
 
-<!-- Arrows behind cards -->
-<path d="M385,285 C465,285 530,360 600,405" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
-<path d="M385,415 C455,415 505,285 575,285" fill="none" stroke="#16a34a" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-green)"/>
-<path d="M655,338 C655,360 655,374 655,392" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
-<path d="M740,485 C715,525 700,548 690,580" fill="none" stroke="#7c3aed" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
-<path d="M875,485 C900,525 922,548 955,580" fill="none" stroke="#ea580c" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-orange)"/>
-<path d="M930,360 C1030,300 1080,277 1180,277" fill="none" stroke="#dc2626" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-red)"/>
-<path d="M930,405 C1035,405 1085,395 1190,395" fill="none" stroke="#ea580c" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-orange)"/>
-<path d="M930,450 C1035,500 1085,545 1190,545" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
-<path d="M1422,587 L1422,635" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
-<path d="M1302,587 C1260,610 1238,624 1220,650" fill="none" stroke="#7c3aed" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
-<path d="M1348,692 C1298,712 1258,724 1210,724" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
-<path d="M1430,692 C1470,715 1500,725 1535,725" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<!-- Category zones inside column 2 -->
+<rect x="505" y="225" width="560" height="150" rx="18" fill="#ecfeff" stroke="#67e8f9" stroke-width="1.4" stroke-dasharray="6 7" opacity="0.9"/>
+<text x="526" y="252" class="category">INGRESS + EXECUTION</text>
+<rect x="505" y="390" width="560" height="160" rx="22" fill="#e0f2fe" stroke="#0284c7" stroke-width="1.8" stroke-dasharray="8 7" opacity="0.95"/>
+<text x="526" y="417" class="category">STRATEGIC CENTER</text>
+<rect x="505" y="595" width="560" height="140" rx="18" fill="#faf5ff" stroke="#c084fc" stroke-width="1.4" stroke-dasharray="6 7" opacity="0.9"/>
+<text x="526" y="622" class="category">MEMORY + CONTEXT</text>
+
+<!-- Connections behind cards -->
+<path d="M385,285 C435,285 475,300 545,300" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
+<path d="M385,425 C455,425 485,302 545,302" fill="none" stroke="#16a34a" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<path d="M645,340 C675,372 708,395 745,420" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<path d="M920,340 C895,360 862,385 825,405" fill="none" stroke="#0f766e" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<path d="M745,530 C720,558 700,588 680,615" fill="none" stroke="#7c3aed" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
+<path d="M825,530 C855,562 902,592 940,615" fill="none" stroke="#ea580c" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-orange)"/>
+<path d="M935,452 C1025,360 1090,278 1190,278" fill="none" stroke="#dc2626" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-red)"/>
+<path d="M935,475 C1045,445 1085,397 1190,397" fill="none" stroke="#2563eb" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-blue)"/>
+<path d="M935,500 C1045,515 1085,548 1190,548" fill="none" stroke="#9333ea" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-purple)"/>
+<path d="M1392,590 L1392,642" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
+<path d="M1320,590 C1280,620 1248,636 1215,650" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
+<path d="M1428,590 C1490,620 1535,640 1568,650" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
+<path d="M1320,692 L1348,692" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gray)"/>
+<path d="M1508,692 L1530,692" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-green)"/>
 
 <!-- Access cards -->
 <g id="mac" filter="url(#shadow)">
@@ -71,75 +83,72 @@
   <text x="137" y="622" class="card-body">from any access surface</text>
 </g>
 
-<!-- Center column cards -->
+<!-- Fedora mini PC cards arranged around the centered Hermes Chat -->
 <g id="gateway" filter="url(#shadow)">
-  <rect x="545" y="242" width="220" height="96" rx="18" fill="#ffffff"/>
-  <rect x="545" y="242" width="220" height="96" rx="18" fill="#d1fae5" stroke="#059669" stroke-width="2.5"/>
-  <text x="567" y="274" class="card-title">Hermes Gateway</text>
-  <text x="567" y="302" class="card-body">messaging bridge</text>
-  <text x="567" y="324" class="card-body">phone/chat ingress</text>
+  <rect x="545" y="270" width="220" height="82" rx="18" fill="#ffffff"/>
+  <rect x="545" y="270" width="220" height="82" rx="18" fill="#d1fae5" stroke="#059669" stroke-width="2.5"/>
+  <text x="567" y="302" class="card-title">Hermes Gateway</text>
+  <text x="567" y="330" class="card-body">messaging ingress</text>
+</g>
+<g id="agent" filter="url(#shadow)">
+  <rect x="815" y="270" width="220" height="82" rx="18" fill="#ffffff"/>
+  <rect x="815" y="270" width="220" height="82" rx="18" fill="#ccfbf1" stroke="#0f766e" stroke-width="2.5"/>
+  <text x="837" y="302" class="card-title">Hermes Agent</text>
+  <text x="837" y="330" class="card-body">tools, skills, browser</text>
 </g>
 <g id="hermes-chat" filter="url(#shadow)">
-  <rect x="590" y="392" width="360" height="114" rx="22" fill="#ffffff"/>
-  <rect x="590" y="392" width="360" height="114" rx="22" fill="#dff4ff" stroke="#0284c7" stroke-width="4"/>
-  <text x="620" y="428" class="card-title">Hermes Chat</text>
-  <text x="620" y="457" class="card-body-strong">CENTER OF THE STRATEGY</text>
-  <text x="620" y="481" class="card-body">conversation → intent → actions</text>
-</g>
-<g id="tools" filter="url(#shadow)">
-  <rect x="815" y="242" width="220" height="96" rx="18" fill="#ffffff"/>
-  <rect x="815" y="242" width="220" height="96" rx="18" fill="#ccfbf1" stroke="#0f766e" stroke-width="2.5"/>
-  <text x="837" y="274" class="card-title">Hermes Agent</text>
-  <text x="837" y="302" class="card-body">tools + browser</text>
-  <text x="837" y="324" class="card-body">terminal + skills</text>
+  <rect x="635" y="410" width="300" height="120" rx="24" fill="#ffffff"/>
+  <rect x="635" y="410" width="300" height="120" rx="24" fill="#dff4ff" stroke="#0284c7" stroke-width="4.5"/>
+  <text x="675" y="448" class="center-title">Hermes Chat</text>
+  <text x="677" y="479" class="card-body-strong">CENTER OF THE STRATEGY</text>
+  <text x="677" y="505" class="card-body">conversation → intent → action</text>
 </g>
 <g id="honcho" filter="url(#shadow)">
-  <rect x="535" y="580" width="285" height="124" rx="18" fill="#ffffff"/>
-  <rect x="535" y="580" width="285" height="124" rx="18" fill="#ede9fe" stroke="#7c3aed" stroke-width="2.5"/>
-  <text x="557" y="612" class="card-title">Honcho</text>
-  <text x="557" y="640" class="card-body-strong">external agent memory</text>
-  <text x="557" y="662" class="card-body">semantic recall + user model</text>
-  <text x="557" y="684" class="card-body">used by Hermes Chat/Agent</text>
+  <rect x="535" y="635" width="285" height="86" rx="18" fill="#ffffff"/>
+  <rect x="535" y="635" width="285" height="86" rx="18" fill="#ede9fe" stroke="#7c3aed" stroke-width="2.5"/>
+  <text x="557" y="667" class="card-title">Honcho</text>
+  <text x="557" y="695" class="card-body-strong">agent memory + recall</text>
 </g>
 <g id="obsidian" filter="url(#shadow)">
-  <rect x="850" y="580" width="220" height="124" rx="18" fill="#ffffff"/>
-  <rect x="850" y="580" width="220" height="124" rx="18" fill="#fef3c7" stroke="#d97706" stroke-width="2.5"/>
-  <text x="872" y="612" class="card-title">Obsidian</text>
-  <text x="872" y="640" class="card-body-strong">external memory</text>
-  <text x="872" y="662" class="card-body">notes vault, CV,</text>
-  <text x="872" y="684" class="card-body">project knowledge</text>
+  <rect x="850" y="635" width="220" height="86" rx="18" fill="#ffffff"/>
+  <rect x="850" y="635" width="220" height="86" rx="18" fill="#fef3c7" stroke="#d97706" stroke-width="2.5"/>
+  <text x="872" y="667" class="card-title">Obsidian</text>
+  <text x="872" y="695" class="card-body-strong">external memory</text>
 </g>
 
-<!-- External systems -->
+<!-- External systems cards arranged by category -->
+<text x="1190" y="244" class="category">MODELS + WORKSPACE</text>
 <g id="openai" filter="url(#shadow)">
-  <rect x="1190" y="235" width="185" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1190" y="235" width="185" height="84" rx="18" fill="#fee2e2" stroke="#dc2626" stroke-width="2.5"/>
-  <text x="1212" y="267" class="card-title">OpenAI</text>
-  <text x="1212" y="295" class="card-body">reasoning APIs</text>
+  <rect x="1190" y="260" width="185" height="84" rx="18" fill="#ffffff"/>
+  <rect x="1190" y="260" width="185" height="84" rx="18" fill="#fee2e2" stroke="#dc2626" stroke-width="2.5"/>
+  <text x="1212" y="292" class="card-title">OpenAI</text>
+  <text x="1212" y="320" class="card-body">reasoning APIs</text>
 </g>
 <g id="gemini" filter="url(#shadow)">
-  <rect x="1410" y="235" width="185" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1410" y="235" width="185" height="84" rx="18" fill="#ffedd5" stroke="#ea580c" stroke-width="2.5"/>
-  <text x="1432" y="267" class="card-title">Gemini</text>
-  <text x="1432" y="295" class="card-body">Google workspace</text>
+  <rect x="1410" y="260" width="185" height="84" rx="18" fill="#ffffff"/>
+  <rect x="1410" y="260" width="185" height="84" rx="18" fill="#ffedd5" stroke="#ea580c" stroke-width="2.5"/>
+  <text x="1432" y="292" class="card-title">Gemini</text>
+  <text x="1432" y="320" class="card-body">Google workspace</text>
 </g>
+<text x="1190" y="386" class="category">CODING DELEGATION</text>
 <g id="coding" filter="url(#shadow)">
-  <rect x="1190" y="355" width="405" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1190" y="355" width="405" height="84" rx="18" fill="#dbeafe" stroke="#2563eb" stroke-width="2.5"/>
-  <text x="1212" y="387" class="card-title">Coding delegates</text>
-  <text x="1212" y="415" class="card-body">Cursor Agent CLI + Codex CLI</text>
+  <rect x="1190" y="405" width="405" height="84" rx="18" fill="#ffffff"/>
+  <rect x="1190" y="405" width="405" height="84" rx="18" fill="#dbeafe" stroke="#2563eb" stroke-width="2.5"/>
+  <text x="1212" y="437" class="card-title">Cursor Agent CLI + Codex CLI</text>
+  <text x="1212" y="465" class="card-body">implementation delegates</text>
 </g>
+<text x="1190" y="530" class="category">WEB APPS + SHIPPING</text>
 <g id="webapps" filter="url(#shadow)">
-  <rect x="1190" y="505" width="405" height="84" rx="18" fill="#ffffff"/>
-  <rect x="1190" y="505" width="405" height="84" rx="18" fill="#f3e8ff" stroke="#9333ea" stroke-width="2.5"/>
-  <text x="1212" y="537" class="card-title">Web apps</text>
-  <text x="1212" y="565" class="card-body">SavedTube + dashboards + product UI</text>
+  <rect x="1190" y="548" width="405" height="84" rx="18" fill="#ffffff"/>
+  <rect x="1190" y="548" width="405" height="84" rx="18" fill="#f3e8ff" stroke="#9333ea" stroke-width="2.5"/>
+  <text x="1212" y="580" class="card-title">Web apps</text>
+  <text x="1212" y="608" class="card-body">SavedTube + dashboards + product UI</text>
 </g>
 <g id="github" filter="url(#shadow)">
   <rect x="1165" y="650" width="160" height="84" rx="18" fill="#ffffff"/>
   <rect x="1165" y="650" width="160" height="84" rx="18" fill="#e2e8f0" stroke="#64748b" stroke-width="2.5"/>
   <text x="1187" y="682" class="card-title">GitHub</text>
-  <text x="1187" y="710" class="card-body">PRs + CI</text>
+  <text x="1187" y="710" class="card-body">source + PRs</text>
 </g>
 <g id="vercel" filter="url(#shadow)">
   <rect x="1348" y="650" width="160" height="84" rx="18" fill="#ffffff"/>
@@ -150,29 +159,31 @@
 <g id="supabase" filter="url(#shadow)">
   <rect x="1530" y="650" width="80" height="84" rx="18" fill="#ffffff"/>
   <rect x="1530" y="650" width="80" height="84" rx="18" fill="#dcfce7" stroke="#16a34a" stroke-width="2.5"/>
-  <text x="1544" y="682" class="card-title" font-size="16">DB</text>
+  <text x="1544" y="682" class="card-title">DB</text>
   <text x="1543" y="710" class="tiny">Supabase</text>
 </g>
 
-<!-- Labels -->
+<!-- Compact flow labels -->
 <rect x="430" y="255" width="128" height="24" rx="8" fill="#fbfdff" stroke="#2563eb" stroke-width="1" opacity="0.96"/>
 <text x="438" y="272" class="small" fill="#2563eb">remote control</text>
 <rect x="416" y="350" width="146" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
 <text x="424" y="367" class="small" fill="#16a34a">phone → gateway</text>
-<rect x="598" y="355" width="112" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
-<text x="606" y="372" class="small" fill="#16a34a">chat ingress</text>
-<rect x="702" y="530" width="98" height="24" rx="8" fill="#fbfdff" stroke="#7c3aed" stroke-width="1" opacity="0.96"/>
-<text x="710" y="547" class="small" fill="#7c3aed">memory</text>
-<rect x="884" y="530" width="132" height="24" rx="8" fill="#fbfdff" stroke="#ea580c" stroke-width="1" opacity="0.96"/>
-<text x="892" y="547" class="small" fill="#ea580c">notes memory</text>
-<rect x="1018" y="302" width="82" height="24" rx="8" fill="#fbfdff" stroke="#dc2626" stroke-width="1" opacity="0.96"/>
-<text x="1026" y="319" class="small" fill="#dc2626">LLMs</text>
-<rect x="1030" y="500" width="130" height="24" rx="8" fill="#fbfdff" stroke="#2563eb" stroke-width="1" opacity="0.96"/>
-<text x="1038" y="517" class="small" fill="#2563eb">build product</text>
-<rect x="1334" y="611" width="118" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
-<text x="1342" y="628" class="small" fill="#64748b">ship path</text>
+<rect x="640" y="374" width="118" height="24" rx="8" fill="#fbfdff" stroke="#16a34a" stroke-width="1" opacity="0.96"/>
+<text x="648" y="391" class="small" fill="#16a34a">chat ingress</text>
+<rect x="840" y="374" width="92" height="24" rx="8" fill="#fbfdff" stroke="#0f766e" stroke-width="1" opacity="0.96"/>
+<text x="848" y="391" class="small" fill="#0f766e">tool use</text>
+<rect x="692" y="558" width="98" height="24" rx="8" fill="#fbfdff" stroke="#7c3aed" stroke-width="1" opacity="0.96"/>
+<text x="700" y="575" class="small" fill="#7c3aed">memory</text>
+<rect x="880" y="558" width="132" height="24" rx="8" fill="#fbfdff" stroke="#ea580c" stroke-width="1" opacity="0.96"/>
+<text x="888" y="575" class="small" fill="#ea580c">notes memory</text>
+<rect x="1038" y="324" width="82" height="24" rx="8" fill="#fbfdff" stroke="#dc2626" stroke-width="1" opacity="0.96"/>
+<text x="1046" y="341" class="small" fill="#dc2626">LLMs</text>
+<rect x="1038" y="500" width="130" height="24" rx="8" fill="#fbfdff" stroke="#9333ea" stroke-width="1" opacity="0.96"/>
+<text x="1046" y="517" class="small" fill="#9333ea">product work</text>
+<rect x="1334" y="626" width="118" height="24" rx="8" fill="#fbfdff" stroke="#64748b" stroke-width="1" opacity="0.96"/>
+<text x="1342" y="643" class="small" fill="#64748b">ship path</text>
 
-<!-- Legend and notes -->
+<!-- Legend and operating notes -->
 <g transform="translate(90,830)">
   <text x="0" y="0" class="section">Flow legend</text>
   <line x1="0" y1="38" x2="54" y2="38" stroke="#2563eb" stroke-width="4" stroke-linecap="round"/>
@@ -190,10 +201,10 @@
   <rect x="560" y="828" width="1065" height="245" rx="22" fill="#ffffff"/>
   <rect x="560" y="828" width="1065" height="245" rx="22" fill="#f8fafc" stroke="#cbd5e1" stroke-width="2"/>
   <text x="600" y="878" class="section">Operating principle</text>
-  <text x="600" y="918" class="subtitle">Hermes Chat is the strategic center: Alfons turns intent into actions, memory, notes, code, and shipped apps.</text>
-  <text x="600" y="950" class="subtitle">Hermes Gateway is not the memory layer; it is the always-on messaging bridge for phone/WhatsApp traffic.</text>
-  <text x="600" y="982" class="subtitle">Messages reach Gateway first, then land in Hermes Chat where Hermes Agent can reason, use tools, and delegate.</text>
-  <text x="600" y="1014" class="subtitle">Honcho is agent memory for semantic recall and user/profile context. Obsidian is external memory as notes.</text>
-  <text x="600" y="1046" class="subtitle">Web apps live outside the machine: GitHub source/PRs, Vercel deploys, Supabase product data.</text>
+  <text x="600" y="918" class="subtitle">The Hermes Chat shape is physically centered in the Fedora box: conversation is the strategic control point.</text>
+  <text x="600" y="950" class="subtitle">Around it by category: Gateway and Agent above, memory/context below, external services to the right.</text>
+  <text x="600" y="982" class="subtitle">Hermes Gateway is not memory; it is messaging ingress. Phone/WhatsApp reaches Gateway first, then Chat.</text>
+  <text x="600" y="1014" class="subtitle">Honcho is agent memory for recall and profile context. Obsidian is external memory as human notes.</text>
+  <text x="600" y="1046" class="subtitle">Web apps sit outside the machine with GitHub source/PRs, Vercel deploys, and Supabase data.</text>
 </g>
 </svg>

--- a/home-hermes-setup.md
+++ b/home-hermes-setup.md
@@ -38,7 +38,7 @@ permalink: /home-hermes-setup/
 
 <div class="diagram-page">
 
-A readable web version of the home AI operating layer: access from Mac and phone into the Fedora mini PC, with Hermes Chat positioned as the strategic center. Phone and voice-note traffic enter through Hermes Gateway, Honcho and Obsidian are shown as external agent-memory/context layers, and web apps are grouped with GitHub, Vercel, and Supabase in the external systems column. The original Excalidraw source is still available below.
+A readable web version of the home AI operating layer: access from Mac and phone into the Fedora mini PC, with Hermes Chat positioned as the strategic center. Phone and voice-note traffic enter through Hermes Gateway, Honcho and Obsidian are shown as external agent-memory/context layers, and GitHub, Vercel, and Supabase are grouped as the shipping stack that feeds the generic web apps surface. The original Excalidraw source is still available below.
 
 <div class="diagram-actions">
   <a href="{{ '/assets/diagrams/home-hermes-setup.svg' | relative_url }}">Open SVG</a>


### PR DESCRIPTION
## Summary
- Moves the Hermes Chat card to the exact geometric center of the Home Fedora mini PC column
- Rearranges the surrounding cards by category: ingress/execution above, strategic center in the middle, memory/context below
- Keeps phone routing through Hermes Gateway and web apps grouped with GitHub, Vercel, and Supabase

## Verification
- Parsed SVG as valid XML
- Verified Hermes Chat center is (785,470), matching the Fedora column center (785,470)
- Visually inspected the local SVG in browser